### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "./"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![The Great Wave](https://upload.wikimedia.org/wikipedia/commons/0/0a/The_Great_Wave_off_Kanagawa.jpg)
+[![Run on Repl.it](https://repl.it/badge/github/sugarfi/Wave)](https://repl.it/github/sugarfi/Wave)
 # Wave
 Wave is a Lisp-like language implemented in Python. Built on top of Numpy and Sympy,
 Wave is both powerful and simple. It can be easily extended to your needs, and is very 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@sugarfi/Wave).